### PR TITLE
fix: remove extra -u flag/parameter

### DIFF
--- a/tools/developer-setup/.glueopsrc
+++ b/tools/developer-setup/.glueopsrc
@@ -44,5 +44,5 @@ dev() {
         fi
     done
 
-    mkdir -p workspaces/glueops; sudo docker run -it --net=host --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --init --device=/dev/net/tun -u $(id -u):$(getent group docker | cut -d: -f3) -v `pwd`/workspaces/glueops:/workspaces/glueops -v /var/run/docker.sock:/var/run/docker.sock -v /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock -u vscode -w /workspaces/glueops ghcr.io/glueops/codespaces:${CONTAINER_TAG_TO_USE} bash -c "code tunnel --random-name --verbose --log trace"
+    mkdir -p workspaces/glueops; sudo docker run -it --net=host --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --privileged --init --device=/dev/net/tun -u $(id -u):$(getent group docker | cut -d: -f3) -v `pwd`/workspaces/glueops:/workspaces/glueops -v /var/run/docker.sock:/var/run/docker.sock -v /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock -w /workspaces/glueops ghcr.io/glueops/codespaces:${CONTAINER_TAG_TO_USE} bash -c "code tunnel --random-name --verbose --log trace"
 }


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Removed an unnecessary `-u` flag from the Docker run command in the `.glueopsrc` file, which was causing issues with user permissions.
- Ensured that the correct user and group IDs are used when running the Docker container.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.glueopsrc</strong><dd><code>Remove redundant `-u` flag from Docker command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/developer-setup/.glueopsrc

<li>Removed an extra <code>-u</code> flag from the Docker run command.<br> <li> Ensured correct user and group ID usage in Docker command.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/35/files#diff-cdd0c036241feeb346820c377dc5c4126e9a3b96df42d84c151191046c616df1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

