### PR TITLE
fix: pinning to a version so things don't break randomly in the future

### DIFF
--- a/tools/developer-setup/linux-setup.sh
+++ b/tools/developer-setup/linux-setup.sh
@@ -27,7 +27,7 @@ sudo groupadd -f docker
 sudo usermod -aG docker vscode
 echo 'fs.inotify.max_user_instances=1024' | sudo tee -a /etc/sysctl.conf
 echo 1024 | sudo tee /proc/sys/fs/inotify/max_user_instances
-sudo curl https://raw.githubusercontent.com/GlueOps/development-only-utilities/main/tools/developer-setup/.glueopsrc --output /home/vscode/.glueopsrc
+sudo curl https://raw.githubusercontent.com/GlueOps/development-only-utilities/v0.11.0/tools/developer-setup/.glueopsrc --output /home/vscode/.glueopsrc
 echo "source /home/vscode/.glueopsrc" | sudo tee -a /home/vscode/.bashrc
 sudo chown -R vscode:vscode /home/vscode
 # disables the password for the current user (ex. root/admin/ubuntu users)


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `linux-setup.sh` script to pin the URL in the curl command to a specific version (v0.11.0) of the `.glueopsrc` file.
- This change ensures that the script will not break due to future changes in the `.glueopsrc` file by using a fixed version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>linux-setup.sh</strong><dd><code>Pin URL to specific version in linux-setup.sh script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/developer-setup/linux-setup.sh

<li>Updated the URL in the curl command to pin to a specific version <br>(v0.11.0).<br> <li> Ensures consistent behavior by using a fixed version of the resource.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/37/files#diff-536aab553657ba2abdfb09ac4ddd89a753d5a910076769f13395f878ae14d092">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

