### PR TITLE
fix: setting uid to 1337 for vscode user

### DIFF
--- a/tools/developer-setup/linux-setup.sh
+++ b/tools/developer-setup/linux-setup.sh
@@ -5,7 +5,7 @@ set -e
 echo -e "\n\nEverything is now getting setup. This process will take a few minutes...\n\n"
 
 # Create user vscode
-sudo adduser --disabled-password --gecos "" vscode
+sudo adduser --disabled-password --uid 1337 --gecos "" vscode
 
 # Create .ssh directory for vscode
 sudo mkdir -p /home/vscode/.ssh


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the user creation script to set the UID for the `vscode` user to 1337, ensuring consistent user ID across environments.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>linux-setup.sh</strong><dd><code>Set UID to 1337 for vscode user creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/developer-setup/linux-setup.sh

- Set the UID for the `vscode` user to 1337 during user creation.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/40/files#diff-536aab553657ba2abdfb09ac4ddd89a753d5a910076769f13395f878ae14d092">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information