### PR TITLE
Revert "fix: setting uid to 1337 for vscode user"

### DIFF
--- a/tools/developer-setup/linux-setup.sh
+++ b/tools/developer-setup/linux-setup.sh
@@ -5,7 +5,7 @@ set -e
 echo -e "\n\nEverything is now getting setup. This process will take a few minutes...\n\n"
 
 # Create user vscode
-sudo adduser --disabled-password --uid 1337 --gecos "" vscode
+sudo adduser --disabled-password --gecos "" vscode
 
 # Create .ssh directory for vscode
 sudo mkdir -p /home/vscode/.ssh


### PR DESCRIPTION
### **User description**
Reverts GlueOps/development-only-utilities#40


___

### **PR Type**
enhancement


___

### **Description**
- Reverts the previous change that set a specific UID (1337) for the vscode user in the Linux setup script.
- The `adduser` command no longer includes the `--uid 1337` option, allowing the system to assign a default UID.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>linux-setup.sh</strong><dd><code>Revert specific UID assignment for vscode user creation</code>&nbsp; &nbsp; </dd></summary>
<hr>

tools/developer-setup/linux-setup.sh

<li>Reverted the user creation command to remove the specific UID <br>assignment.<br> <li> The <code>--uid 1337</code> option was removed from the <code>adduser</code> command.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/41/files#diff-536aab553657ba2abdfb09ac4ddd89a753d5a910076769f13395f878ae14d092">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information