### PR TITLE
major: migrating to new aws-nuke

### DIFF
--- a/tools/aws/account-nuke.sh
+++ b/tools/aws/account-nuke.sh
@@ -4,7 +4,7 @@
 ##
 set -e
 echo -e "\n"
-AWS_NUKE_VERSION=v2.25.0
+AWS_NUKE_VERSION=v3.29.5
 
 [ "$(aws sts get-caller-identity --query Account --output text)" = "$(aws organizations describe-organization --query Organization.MasterAccountId --output text)" ] && echo -e "\e[32mTHIS IS THE ROOT ACCOUNT. PLEASE PROCEED\e[0m" || echo -e "\e[31mTHIS IS NOT THE ROOT ACCOUNT STOP IMMEDIATELY.\e[0m"
 echo -e "\n"
@@ -12,7 +12,7 @@ echo "Please enter your AWS account name. It should start with glueops-captain (
 echo ""
 read ACCOUNT_NAME
 echo -e "\n"
-wget https://github.com/rebuy-de/aws-nuke/releases/download/$AWS_NUKE_VERSION/aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && tar -xvf aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && rm aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && mv aws-nuke-$AWS_NUKE_VERSION-linux-amd64 aws-nuke
+wget https://github.com/ekristen/aws-nuke/releases/download/$AWS_NUKE_VERSION/aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && tar -xvf aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && rm aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && mv aws-nuke-$AWS_NUKE_VERSION-linux-amd64 aws-nuke
 SUB_ACCOUNT_ID=$(aws organizations list-accounts --output json | jq -r --arg ACCOUNT_NAME "$ACCOUNT_NAME" '.Accounts[] | select(.Name==$ACCOUNT_NAME) | .Id')
 
 cat << 'EOF' > nuke.yaml


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Migrated to a new version of AWS Nuke, updating from v2.25.0 to v3.29.5.
- Changed the download source URL for AWS Nuke to a new repository.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>account-nuke.sh</strong><dd><code>Update AWS Nuke version and download source URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/aws/account-nuke.sh

<li>Updated AWS Nuke version from v2.25.0 to v3.29.5.<br> <li> Changed the download source URL for AWS Nuke.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/50/files#diff-102fa70e45ca00a0f3faf7a2b9bef2764a7246f40a067628e6e24b4baad7f782">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information