### PR TITLE
fix: remove rename of aws-nuke since it's already named correctly in …

### DIFF
--- a/tools/aws/account-nuke.sh
+++ b/tools/aws/account-nuke.sh
@@ -12,7 +12,7 @@ echo "Please enter your AWS account name. It should start with glueops-captain (
 echo ""
 read ACCOUNT_NAME
 echo -e "\n"
-wget https://github.com/ekristen/aws-nuke/releases/download/$AWS_NUKE_VERSION/aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && tar -xvf aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && rm aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && mv aws-nuke-$AWS_NUKE_VERSION-linux-amd64 aws-nuke
+wget https://github.com/ekristen/aws-nuke/releases/download/$AWS_NUKE_VERSION/aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && tar -xvf aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && rm aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz
 SUB_ACCOUNT_ID=$(aws organizations list-accounts --output json | jq -r --arg ACCOUNT_NAME "$ACCOUNT_NAME" '.Accounts[] | select(.Name==$ACCOUNT_NAME) | .Id')
 
 cat << 'EOF' > nuke.yaml


### PR DESCRIPTION
### **User description**
…the new fork/version


___

### **PR Type**
bug_fix


___

### **Description**
- Removed the unnecessary renaming of the `aws-nuke` binary in the `account-nuke.sh` script, as it is already correctly named in the new fork/version.
- Simplified the script by eliminating the redundant `mv` command, which improves script efficiency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>account-nuke.sh</strong><dd><code>Remove redundant renaming of aws-nuke binary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/aws/account-nuke.sh

<li>Removed unnecessary renaming of the <code>aws-nuke</code> binary after extraction.<br> <li> Simplified the script by eliminating redundant <code>mv</code> command.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/51/files#diff-102fa70e45ca00a0f3faf7a2b9bef2764a7246f40a067628e6e24b4baad7f782">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information