### PR TITLE
fix: nuke command

### DIFF
--- a/tools/aws/account-nuke.sh
+++ b/tools/aws/account-nuke.sh
@@ -70,7 +70,7 @@ export AWS_SECRET_ACCESS_KEY=$secretAccessKey
 export AWS_DEFAULT_REGION=us-west-2
 
 
-./aws-nuke -c nuke.yaml --no-dry-run --force
+./aws-nuke nike -c nuke.yaml --no-dry-run --force
 
 rm nuke.yaml
 rm aws-nuke


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the command syntax in the `account-nuke.sh` script to correctly execute the `aws-nuke` tool.
- Ensured the script uses the correct command to prevent execution errors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>account-nuke.sh</strong><dd><code>Fix command syntax for aws-nuke execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/aws/account-nuke.sh

<li>Corrected the command syntax for executing <code>aws-nuke</code>.<br> <li> Replaced incorrect command <code>./aws-nuke</code> with <code>./aws-nuke nike</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/52/files#diff-102fa70e45ca00a0f3faf7a2b9bef2764a7246f40a067628e6e24b4baad7f782">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information