### PR TITLE
fix: typo of nike -> nuke

### DIFF
--- a/tools/aws/account-nuke.sh
+++ b/tools/aws/account-nuke.sh
@@ -70,7 +70,7 @@ export AWS_SECRET_ACCESS_KEY=$secretAccessKey
 export AWS_DEFAULT_REGION=us-west-2
 
 
-./aws-nuke nike -c nuke.yaml --no-dry-run --force
+./aws-nuke nuke -c nuke.yaml --no-dry-run --force
 
 rm nuke.yaml
 rm aws-nuke


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a typo in the `aws-nuke` command within the `account-nuke.sh` script by changing `nike` to `nuke`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>account-nuke.sh</strong><dd><code>Fix typo in aws-nuke command execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/aws/account-nuke.sh

<li>Corrected a typo in the command execution line.<br> <li> Changed <code>nike</code> to <code>nuke</code> in the aws-nuke command.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/53/files#diff-102fa70e45ca00a0f3faf7a2b9bef2764a7246f40a067628e6e24b4baad7f782">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information