### PR TITLE
feat: create download-qcow2-image.sh for github.com/glueops/theprovisioner

### DIFF
--- a/tools/developer-setup/download-qcow2-image.sh
+++ b/tools/developer-setup/download-qcow2-image.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+
+if [ -z "$TAG" ]; then
+  echo ""
+  echo "TAG environment variable is required"
+  echo "e.g. export TAG=v1.0.0"
+  echo ""
+  exit 1
+fi
+
+# Replace these variables with your repository details
+owner="GlueOps"
+repo="codespaces"
+
+if [ -f "$TAG.qcow2" ]; then
+  echo "File $TAG.qcow2.tar already exists. Skipping download."
+  echo "Cleaning up any files"
+  rm -rf $TAG.qcow2.tar*
+else
+  # Capture the start time
+  start_time=$(date +%s)
+
+  # Get the release ID for the specified tag
+  release_id=$(curl -s "https://api.github.com/repos/$owner/$repo/releases/tags/$TAG" | jq -r '.id')
+
+  # Get the asset download URLs
+  asset_urls=$(curl -s "https://api.github.com/repos/$owner/$repo/releases/$release_id/assets" | jq -r '.[].browser_download_url')
+
+  # Download each asset in parallel
+  for url in $asset_urls; do
+    echo "Downloading $url"
+    curl -L -O "$url" &
+  done
+
+  # Wait for all background jobs to complete
+  wait
+
+  # Calculate and display elapsed time
+  end_time=$(date +%s)
+  elapsed_time=$((end_time - start_time))
+  echo "Total time taken: $elapsed_time seconds"
+
+
+  cat $TAG.qcow2.tar.part_* > $TAG.qcow2.tar
+  tar -xvf $TAG.qcow2.tar
+  echo "Deleting downloaded .tar files"
+  rm -rf $TAG.qcow2.tar*
+fi


### PR DESCRIPTION
### **User description**
feat: create download-qcow2-image.sh for github.com/glueops/theprovisioner


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new shell script `download-qcow2-image.sh` to automate the download of qcow2 images from GitHub releases.
- The script requires a `TAG` environment variable to specify the release version.
- It retrieves asset URLs from the specified GitHub repository and downloads them in parallel.
- The script includes functionality to clean up and extract the downloaded files.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>download-qcow2-image.sh</strong><dd><code>Add script for downloading qcow2 images from GitHub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/developer-setup/download-qcow2-image.sh

<li>Added a new script to download qcow2 images.<br> <li> Checks for the presence of a <code>TAG</code> environment variable.<br> <li> Downloads assets from a specified GitHub repository release.<br> <li> Handles file cleanup and extraction of downloaded assets.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/57/files#diff-b83bc7576ae46e421e677d3fd75497c8fc4cddf7b8278b1389fe97f7b4ca6f9f">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information