### PR TITLE
feat: add set -e to stop exec on error in qcow2 img download

### DIFF
--- a/tools/developer-setup/download-qcow2-image.sh
+++ b/tools/developer-setup/download-qcow2-image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ -z "$VM_NAME" ] || [ -z "$TAG" ]; then
   echo ""
   [ -z "$VM_NAME" ] && echo "VM_NAME environment variable is required" && echo "e.g. export VM_NAME=dinosaur-cat" && echo ""


### PR DESCRIPTION
### **PR Type**
enhancement, error handling


___

### **Description**
- Enhanced the `download-qcow2-image.sh` script by adding `set -e` to stop execution on error, improving the script's robustness.
- Ensures that the script exits immediately if any command fails, preventing further execution with potential errors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>download-qcow2-image.sh</strong><dd><code>Add error handling with `set -e` in Bash script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/developer-setup/download-qcow2-image.sh

<li>Added <code>set -e</code> to the script to stop execution on error.<br> <li> Improved error handling by ensuring the script exits on failure.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/59/files#diff-b83bc7576ae46e421e677d3fd75497c8fc4cddf7b8278b1389fe97f7b4ca6f9f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information