### PR TITLE
feat: adding support for running aws nuke script without user input

### DIFF
--- a/tools/aws/account-nuke.sh
+++ b/tools/aws/account-nuke.sh
@@ -7,10 +7,22 @@ echo -e "\n"
 AWS_NUKE_VERSION=v3.29.5
 
 [ "$(aws sts get-caller-identity --query Account --output text)" = "$(aws organizations describe-organization --query Organization.MasterAccountId --output text)" ] && echo -e "\e[32mCHECKS PASSED. PLEASE PROCEED\e[0m" || echo -e "\e[31mYOU MUST RUN THIS FROM THE ROOT ORG ACCOUNT. STOP IMMEDIATELY.\e[0m"
-echo -e "\n"
-echo -e "\e[31mPlease enter your AWS account name. This account will have ALL of it's resources destroyed! It should start with glueops-captain (e.g. glueops-captain-laciudaddelgato):\e[0m"
-echo ""
-read ACCOUNT_NAME
+
+
+# Check if the environment variable is set
+if [ -z "$AWS_ACCOUNT_NAME_TO_NUKE" ]; then
+  # If not set, prompt for the account name
+  echo -e "\n"
+  echo -e "\e[31mPlease enter your AWS account name. This account will have ALL of its resources destroyed! It should start with glueops-captain (e.g. glueops-captain-laciudaddelgato):\e[0m"
+  echo ""
+  read -p "Account Name: " AWS_ACCOUNT_NAME_TO_NUKE
+  echo -e "\n"
+fi
+
+# Now AWS_ACCOUNT_NAME_TO_NUKE will contain the value (either from the environment or user input)
+echo "The AWS account name to nuke is: $AWS_ACCOUNT_NAME_TO_NUKE"
+
+ACCOUNT_NAME=$AWS_ACCOUNT_NAME_TO_NUKE
 echo -e "\n"
 wget https://github.com/ekristen/aws-nuke/releases/download/$AWS_NUKE_VERSION/aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && tar -xvf aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz && rm aws-nuke-$AWS_NUKE_VERSION-linux-amd64.tar.gz
 SUB_ACCOUNT_ID=$(aws organizations list-accounts --output json | jq -r --arg ACCOUNT_NAME "$ACCOUNT_NAME" '.Accounts[] | select(.Name==$ACCOUNT_NAME) | .Id')


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added support for running AWS nuke script without user input.

- Introduced environment variable `AWS_ACCOUNT_NAME_TO_NUKE` for account name input.

- Retained manual input as a fallback if the environment variable is unset.

- Improved script flexibility and automation for account nuking.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>account-nuke.sh</strong><dd><code>Support environment variable for AWS account name input</code>&nbsp; &nbsp; </dd></summary>
<hr>

tools/aws/account-nuke.sh

<li>Added logic to check for <code>AWS_ACCOUNT_NAME_TO_NUKE</code> environment <br>variable.<br> <li> Provided fallback to prompt user for account name if the variable is <br>unset.<br> <li> Echoed the account name to be nuked for confirmation.<br> <li> Enhanced script automation and usability.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/60/files#diff-102fa70e45ca00a0f3faf7a2b9bef2764a7246f40a067628e6e24b4baad7f782">+16/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information