### PR TITLE
feat: update tenant-s3-nuke.sh to use an env override for the tenant …

### DIFF
--- a/tools/aws/tenant-s3-nuke.sh
+++ b/tools/aws/tenant-s3-nuke.sh
@@ -4,11 +4,21 @@ set -e
 echo -e "\n"
 
 [ "$(aws sts get-caller-identity --query Account --output text)" = "$(aws organizations describe-organization --query Organization.MasterAccountId --output text)" ] || (echo -e "\e[31mTHIS IS NOT THE ROOT ACCOUNT STOP IMMEDIATELY.\e[0m" && exit 1)
+
 echo -e "\n"
-echo -e "\e[31mTHIS SCRIPT WILL DELETE ALL YOUR BACKUPS FOR YOUR TENANT. This includes but isn't limited to loki backups and vault backups.\e[0m" 
+echo -e "\e[31mTHIS SCRIPT WILL DELETE ALL YOUR BACKUPS FOR YOUR TENANT. This includes but isn't limited to loki backups and vault backups.\e[0m"
 echo "Please enter your captain domain example: nonprod.earth.onglueops.rocks :"
 echo ""
-read CAPTAIN_DOMAIN
+
+# Check if the variable is undefined or empty
+if [ -z "$CAPTAIN_DOMAIN_TO_NUKE" ]; then
+    read -p "CAPTAIN_DOMAIN_TO_NUKE is undefined. Please enter the captain domain to nuke: " CAPTAIN_DOMAIN_TO_NUKE
+fi
+
+# Optional: If you want to confirm the value after prompt
+echo "You entered: $CAPTAIN_DOMAIN_TO_NUKE"
+
+CAPTAIN_DOMAIN=$CAPTAIN_DOMAIN_TO_NUKE
 IFS='.' read -ra ADDR <<< "$CAPTAIN_DOMAIN"
 
 # Assign each part to a specific variable


### PR DESCRIPTION
### **User description**
…to nuke instead of always being prompted


___

### **PR Type**
Enhancement


___

### **Description**
- Added environment variable override for tenant domain input.

- Updated script to prompt only if variable is unset.

- Enhanced user feedback with confirmation of entered domain.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tenant-s3-nuke.sh</strong><dd><code>Support environment variable override for tenant domain</code>&nbsp; &nbsp; </dd></summary>
<hr>

tools/aws/tenant-s3-nuke.sh

<li>Added support for <code>CAPTAIN_DOMAIN_TO_NUKE</code> environment variable.<br> <li> Modified script to prompt user only if the variable is unset.<br> <li> Included confirmation message for entered domain.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/61/files#diff-4c145333cdc15f5b5f7c3797e1f308c9f3f82916bd06c67b409d7c04bf5058df">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information