### PR TITLE
feat: add a second execution of the nuke script

### DIFF
--- a/tools/aws/account-nuke.sh
+++ b/tools/aws/account-nuke.sh
@@ -87,6 +87,7 @@ export AWS_SECRET_ACCESS_KEY=$secretAccessKey
 export AWS_DEFAULT_REGION=us-west-2
 
 
+./aws-nuke nuke -c nuke.yaml --max-wait-retries 200 --no-dry-run --force --log-level debug --log-full-timestamp true --log-caller true || true
 ./aws-nuke nuke -c nuke.yaml --max-wait-retries 200 --no-dry-run --force --log-level debug --log-full-timestamp true --log-caller true
 
 rm nuke.yaml


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add second execution of aws-nuke command with error tolerance

- Improve reliability by running nuke operation twice


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["First aws-nuke execution"] -- "with error tolerance" --> B["Second aws-nuke execution"]
  B -- "ensures cleanup" --> C["Remove config files"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>account-nuke.sh</strong><dd><code>Add redundant aws-nuke execution with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/aws/account-nuke.sh

<ul><li>Add duplicate aws-nuke command execution before existing one<br> <li> First execution includes <code>|| true</code> for error tolerance<br> <li> Maintains same configuration and parameters for both runs</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/development-only-utilities/pull/71/files#diff-102fa70e45ca00a0f3faf7a2b9bef2764a7246f40a067628e6e24b4baad7f782">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

