### PR TITLE
feat: install kube-prometheus-stack CRDs in deploy-argocd

### DIFF
--- a/tools/glueops-platform/deploy-argocd
+++ b/tools/glueops-platform/deploy-argocd
@@ -2,6 +2,7 @@
    deploy-argocd() {
     crd_version=""
     helm_version=""
+    kube_prometheus_stack_version=""
 
     # Parse flags
     while [[ $# -gt 0 ]]; do
@@ -17,12 +18,18 @@
           shift
           shift
           ;;
+        (-p|--kube-prometheus-stack-version)
+          kube_prometheus_stack_version="$2"
+          shift
+          shift
+          ;;
         (--help)
           echo "Usage: deploy-argocd [options]"
           echo ""
           echo "Options:"
           echo "  -c, --crd-version VALUE   Set the version for ArgoCD CRDs to deploy"
           echo "  -h, --helm-version VALUE  Set the version of the ArgoCD Helm Chart to deploy"
+          echo "  -p, --kube-prometheus-stack-version VALUE  Set the version of the kube-prometheus-stack chart whose CRDs will be deployed"
           echo "  --help                    Show this help message and exit"
           return
           ;;
@@ -35,13 +42,20 @@
     done
 
     # Check if version arguments were provided
-    if [[ -z $crd_version || -z $helm_version ]]; then
-        echo "Both arguments are required."
+    if [[ -z $crd_version || -z $helm_version || -z $kube_prometheus_stack_version ]]; then
+        echo "All arguments are required."
         echo "Run 'deploy-argocd --help' for usage information."
         return
     fi
     
+    # The kube-prometheus-stack CRDs are applied server-side because they are too
+    # large for client-side apply. Sparse clone keeps the checkout to just the CRD folder.
+    crds_dir=$(mktemp -d)
     kubectl apply -k "https://github.com/argoproj/argo-cd/manifests/crds?ref=$crd_version" && \
+    git -c advice.detachedHead=false clone --quiet --depth 1 --branch "kube-prometheus-stack-${kube_prometheus_stack_version}" --filter=blob:none --sparse https://github.com/prometheus-community/helm-charts.git "$crds_dir" && \
+    git -C "$crds_dir" sparse-checkout set --no-cone charts/kube-prometheus-stack/charts/crds/crds && \
+    kubectl apply --server-side --force-conflicts -R -f "$crds_dir/charts/kube-prometheus-stack/charts/crds/crds" && \
+    rm -rf "$crds_dir" && \
     helm repo update && \
     helm install argocd argo/argo-cd --skip-crds --version $helm_version -f argocd.yaml --namespace=glueops-core --create-namespace && \
     echo "--------------------------------------------------------------"


### PR DESCRIPTION
## Summary
- `deploy-argocd` gains a required `-p/--kube-prometheus-stack-version` flag and installs the kube-prometheus-stack CRDs right after the ArgoCD CRDs, replacing the `kube-prometheus-stack-crds` ArgoCD Application from [platform-helm-chart-platform](https://github.com/GlueOps/platform-helm-chart-platform/blob/main/templates/application-kube-prometheus-stack-crds.yaml).

## How it works
- The whole CRD folder (`charts/kube-prometheus-stack/charts/crds/crds`) is sparse-cloned from `prometheus-community/helm-charts` at tag `kube-prometheus-stack-<version>` and applied with one `kubectl apply --server-side --force-conflicts -R -f` — no hardcoded file list, matching the app's `directory.recurse: true`.
- Server-side apply is the kubectl equivalent of the app's `Replace=true` (the prometheus/alertmanager CRDs exceed the client-side apply annotation limit).

## Related
- GlueOps/terraform-module-cloud-multy-prerequisites#648 updates the generated tenant README to pass `-p` (and adds the version to `VERSIONS/glueops.yaml`). After this PR is released, `local.tools_version` in that repo must be bumped to the new release so the README sources a `deploy-argocd` that understands `-p`.
- GlueOps/codespaces#515 makes the same change for captain_utils.

🤖 Generated with [Claude Code](https://claude.com/claude-code)